### PR TITLE
feat: add ESM build support with dual CommonJS/ESM exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,25 @@
 
 ## [Unreleased]
 
+## v1.2.1
+
 ### Added
 
+- ESM build support with dual CommonJS/ESM exports
+- Separate TypeScript configurations for ESM and CommonJS builds
+- Build script to fix ESM imports with .js extensions
+- Support for both import and require syntax
+- CONTRIBUTING.md with contribution guidelines
 - Enhanced package.json exports field for better module resolution
 - Support for subpath exports allowing cleaner imports (e.g., `@devmehq/sdk-js/api`)
 - Proper TypeScript types exports for all subpaths
 - Files field in package.json to optimize npm package size
+
+### Changed
+
+- Updated SDK types and client structure
+- Improved API structure and code formatting
+- Enhanced linting configuration
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to DevMe SDK JS
+
+Thank you for your interest in contributing to DevMe SDK JS! We welcome contributions from the community.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Create a new branch for your feature or fix
+4. Make your changes
+5. Push to your fork
+6. Submit a pull request to the `master` branch
+
+## Development Setup
+
+```bash
+# Install dependencies
+npm install
+
+# Run tests
+npm test
+
+# Run linter
+npm run lint
+
+# Run type checking
+npm run typecheck
+
+# Build the project
+npm run build
+```
+
+## Code Style
+
+- Follow the existing code style in the project
+- Use TypeScript for all new code
+- Ensure all tests pass before submitting
+- Run linter and fix any issues
+- Ensure type checking passes
+
+## Commit Messages
+
+- Use clear and descriptive commit messages
+- Follow conventional commit format when possible:
+  - `feat:` for new features
+  - `fix:` for bug fixes
+  - `docs:` for documentation changes
+  - `refactor:` for code refactoring
+  - `test:` for test additions or changes
+  - `chore:` for maintenance tasks
+
+## Pull Request Process
+
+1. Update the README.md with details of changes if applicable
+2. Ensure all tests pass
+3. Update documentation as needed
+4. Request review from maintainers
+5. Address any feedback provided
+
+## Reporting Issues
+
+- Use GitHub Issues to report bugs
+- Provide clear reproduction steps
+- Include relevant system information
+- Attach any relevant logs or screenshots
+
+## Questions?
+
+Feel free to open an issue for any questions about contributing.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the same license as the project.

--- a/README.md
+++ b/README.md
@@ -616,12 +616,12 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE.md) f
 ## 🆘 Support
 
 - 📧 Email: [support@dev.me](mailto:support@dev.me)
-- 📚 Documentation: [dev.me/docs](https://dev.me/docs)
-- 🐦 Twitter: [@devmedotme](https://twitter.com/devmedotme)
+- 📚 Documentation: [dev.me/documentation](https://dev.me/documentation)
+- 🐦 Twitter: [@devhq](https://x.com/devhq)
 
 ## 🔗 Links
 
-- [API Documentation](https://dev.me/docs)
+- [API Documentation](https://dev.me/documentation)
 - [Pricing](https://dev.me/pricing)
 - [Blog](https://dev.me/blog)
 - [Changelog](CHANGELOG.md)

--- a/package.json
+++ b/package.json
@@ -28,39 +28,55 @@
   },
   "license": "MIT",
   "author": "DEV.ME <support@dev.me> (https://dev.me)",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "typings": "./dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "typings": "./dist/cjs/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": {
+        "import": "./dist/esm/index.d.ts",
+        "require": "./dist/cjs/index.d.ts"
+      },
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
     },
     "./api": {
-      "types": "./dist/api.d.ts",
-      "require": "./dist/api.js",
-      "import": "./dist/api.js",
-      "default": "./dist/api.js"
+      "types": {
+        "import": "./dist/esm/api.d.ts",
+        "require": "./dist/cjs/api.d.ts"
+      },
+      "import": "./dist/esm/api.js",
+      "require": "./dist/cjs/api.js",
+      "default": "./dist/cjs/api.js"
     },
     "./configuration": {
-      "types": "./dist/configuration.d.ts",
-      "require": "./dist/configuration.js",
-      "import": "./dist/configuration.js",
-      "default": "./dist/configuration.js"
+      "types": {
+        "import": "./dist/esm/configuration.d.ts",
+        "require": "./dist/cjs/configuration.d.ts"
+      },
+      "import": "./dist/esm/configuration.js",
+      "require": "./dist/cjs/configuration.js",
+      "default": "./dist/cjs/configuration.js"
     },
     "./base": {
-      "types": "./dist/base.d.ts",
-      "require": "./dist/base.js",
-      "import": "./dist/base.js",
-      "default": "./dist/base.js"
+      "types": {
+        "import": "./dist/esm/base.d.ts",
+        "require": "./dist/cjs/base.d.ts"
+      },
+      "import": "./dist/esm/base.js",
+      "require": "./dist/cjs/base.js",
+      "default": "./dist/cjs/base.js"
     },
     "./common": {
-      "types": "./dist/common.d.ts",
-      "require": "./dist/common.js",
-      "import": "./dist/common.js",
-      "default": "./dist/common.js"
+      "types": {
+        "import": "./dist/esm/common.d.ts",
+        "require": "./dist/cjs/common.d.ts"
+      },
+      "import": "./dist/esm/common.js",
+      "require": "./dist/cjs/common.js",
+      "default": "./dist/cjs/common.js"
     },
     "./package.json": "./package.json"
   },
@@ -72,7 +88,11 @@
     "package.json"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc -p .",
+    "build": "rm -rf dist && yarn build:cjs && yarn build:esm && yarn build:fix-esm && yarn build:package-json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:fix-esm": "node scripts/fix-esm-imports.js",
+    "build:package-json": "echo '{\"type\": \"module\"}' > dist/esm/package.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/scripts/fix-esm-imports.js
+++ b/scripts/fix-esm-imports.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+function addJsExtensions(dir) {
+  const files = fs.readdirSync(dir, { withFileTypes: true });
+  
+  for (const file of files) {
+    const filePath = path.join(dir, file.name);
+    
+    if (file.isDirectory()) {
+      addJsExtensions(filePath);
+    } else if (file.name.endsWith('.js')) {
+      let content = fs.readFileSync(filePath, 'utf8');
+      
+      // Fix relative imports to add .js extension
+      content = content.replace(
+        /from\s+['"](\.\/[^'"]+)(?<!\.js)['"]/g,
+        "from '$1.js'"
+      );
+      
+      // Fix export statements
+      content = content.replace(
+        /export\s+\*\s+from\s+['"](\.\/[^'"]+)(?<!\.js)['"]/g,
+        "export * from '$1.js'"
+      );
+      
+      // Fix import statements
+      content = content.replace(
+        /import\s+(.+)\s+from\s+['"](\.\/[^'"]+)(?<!\.js)['"]/g,
+        "import $1 from '$2.js'"
+      );
+      
+      fs.writeFileSync(filePath, content);
+    }
+  }
+}
+
+// Fix ESM imports in dist/esm directory
+const esmDir = path.join(__dirname, '..', 'dist', 'esm');
+if (fs.existsSync(esmDir)) {
+  addJsExtensions(esmDir);
+  console.log('Fixed ESM import extensions');
+} else {
+  console.error('ESM build directory not found');
+  process.exit(1);
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "ES2020",
+    "target": "ES2020",
+    "declaration": true,
+    "declarationDir": "./dist/esm"
+  }
+}


### PR DESCRIPTION
## Summary
- Added full ESM (ECMAScript Modules) support alongside existing CommonJS
- Configured dual build output for maximum compatibility
- Added contribution guidelines

## Changes
- **TypeScript Configuration**: Created separate configs for ESM (`tsconfig.esm.json`) and CommonJS (`tsconfig.cjs.json`) builds
- **Package.json Updates**: 
  - Configured proper dual exports with conditional paths for import/require
  - Added `module` field pointing to ESM build
  - Updated build scripts to generate both formats
- **ESM Compatibility**: Added post-build script to fix ESM imports with `.js` extensions
- **Build Output Structure**:
  - `dist/cjs/` - CommonJS build with type marker
  - `dist/esm/` - ESM build with type marker
- **Documentation**: Added CONTRIBUTING.md with development guidelines

## Test Plan
- [x] Build runs successfully with `yarn build`
- [x] ESM imports work: `import { Configuration } from '@devmehq/sdk-js'`
- [x] CommonJS requires work: `const { Configuration } = require('@devmehq/sdk-js')`
- [x] Both module formats tested and verified
- [ ] Review package installation in consuming projects
- [ ] Verify unpkg.com CDN compatibility remains intact